### PR TITLE
fixbug 导入数据库的建表SQL出错，删除ROW_FORMAT=DYNAMIC这一句就可以了。

### DIFF
--- a/data/db.sql
+++ b/data/db.sql
@@ -213,7 +213,7 @@ CREATE TABLE `cms_category` (
   `list_template` varchar(150) DEFAULT NULL COMMENT '列表页模板',
   `content_template` varchar(150) DEFAULT NULL COMMENT '内容页模板',
   PRIMARY KEY (`id`) USING BTREE
-) ENGINE=InnoDB AUTO_INCREMENT=39 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=COMPACT;
+) ENGINE=InnoDB AUTO_INCREMENT=39 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1203,7 +1203,7 @@ CREATE TABLE `wf_flow_process` (
   `work_sql` longtext,
   `work_msg` longtext,
   PRIMARY KEY (`id`) USING BTREE
-) ENGINE=InnoDB AUTO_INCREMENT=67 DEFAULT CHARSET=utf8 ROW_FORMAT=COMPACT;
+) ENGINE=InnoDB AUTO_INCREMENT=67 DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --


### PR DESCRIPTION
系统 MacOS 11.2.2 数据库 Mariadb 10.5.9
报错内容:
ERROR 1118 (42000) : Row size too large (> 8126). Changing some columns to TEXT or BLOB or using ROW_FORMAT=DYNAMIC or ROW_FORMAT=COMPRESSED may help. In current row format, BLOB prefix of 768 bytes is stored inline.