### PR TITLE
fix 修复标准返回结果数据结构

### DIFF
--- a/library/libResponse/response.go
+++ b/library/libResponse/response.go
@@ -60,12 +60,11 @@ func (res *Response) RJson(r *ghttp.Request, code int, msg string, data ...inter
 	if len(data) > 0 {
 		responseData = data[0]
 	}
-	response = &Response{
+	r.Response.WriteJson(&Response{
 		Code: code,
 		Msg:  msg,
 		Data: responseData,
-	}
-	r.Response.WriteJson(response)
+	})
 }
 
 // 成功返回JSON


### PR DESCRIPTION
标准返回赋给全局变量 response 是会造成严重问题的。

如果有多个同一时间的请求会有数据错乱的情况，造成这种情况的原因是使用的全局变量 response。